### PR TITLE
I1 6 visitor nav restrictions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
       elsif current_admin?
         redirect_to "/admin"
       else
-        redirect_to "/users/#{user.id}"
+        redirect_to "/profile"
       end
     else
       flash[:error] = "Sorry, your credentials are bad."

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(session[:user_id])
+    if session[:user_id]
+      @user = User.find(session[:user_id])
+    else
+      render file: "/public/404"
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
 
   get "/register", to: "users#new"
   post "/register", to: "users#create"
-  get "/users/:id", to: "users#show"
+  get "/profile", to: "users#show"
 
   namespace :admin do
     get '/', to: 'dashboard#show'

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -68,6 +68,20 @@ describe 'When I look at the navigation bar' do
 
       expect(current_path).to eq('/login')
     end
+
+    it 'if I try to go to the merchant, admin, or profile page I see a 404 error' do
+      visit '/merchant'
+
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit '/profile'
+
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+
+      visit '/admin'
+
+      expect(page).to have_content("The page you were looking for doesn't exist.")
+    end
   end
 
   describe 'as a default user' do
@@ -151,7 +165,7 @@ describe 'When I look at the navigation bar' do
 
 
   describe "as a merchant employee" do
-    it "shows the same links as a regular user and a linnk to the merchant dashboard" do
+    it "shows the same links as a regular user and a link to the merchant dashboard" do
       merchant_1 = User.create(name: 'Bill Gates',
                           address: '1000 Microsoft Drive',
                           city: 'Seattle',

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Logging In" do
 
       click_on "Log In"
 
-      expect(current_path).to eq("/users/#{user.id}")
+      expect(current_path).to eq("/profile")
       expect(page).to have_content("Welcome, #{user.name}, you are logged in!")
     end
   end


### PR DESCRIPTION
Added tests and fixed so will now show 404 when a user enters the /profile path.

[Here is the review video.](https://www.loom.com/share/e167cb05943f4b269f7f9fed89e8984d)