### PR TITLE
I2 21 edit password

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,21 +43,22 @@ class UsersController < ApplicationController
   end
 
   # def editpassword
-  #
-  #   @user = User.find(params[:user_id])
+  #   @user = User.find(params[:id])
   # end
   #update_password
-  def edit_password
+  def update_password
     @user = User.find(params[:user_id])
     @user.update(user_password_params)
+    binding.pry
     if @user.save
-      flash[:success] = "#{user_password_params["name"]}, your profile has been updated!"
-      redirect_to "/profile"
+      flash[:success] = "#{current_user.name}, your password has been updated!"
+      redirect_to "/"
     else
       flash[:errors] = "Passwords must match"
       render :edit
     end
   end
+
 
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,6 +42,23 @@ class UsersController < ApplicationController
     end
   end
 
+  # def editpassword
+  #
+  #   @user = User.find(params[:user_id])
+  # end
+  #update_password
+  def edit_password
+    @user = User.find(params[:user_id])
+    @user.update(user_password_params)
+    if @user.save
+      flash[:success] = "#{user_password_params["name"]}, your profile has been updated!"
+      redirect_to "/profile"
+    else
+      flash[:errors] = "Passwords must match"
+      render :edit
+    end
+  end
+
 
   private
   def user_params
@@ -50,6 +67,10 @@ class UsersController < ApplicationController
 
   def user_edit_params
     params.permit(:name, :address, :city, :state, :zip, :email)
+  end
+
+  def user_password_params
+    params.permit(:password)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,10 +51,10 @@ class UsersController < ApplicationController
     @user.update(user_password_params)
     if @user.save
       flash[:success] = "#{current_user.name}, your password has been updated!"
-      redirect_to "/"
+      redirect_to "/profile"
     else
       flash[:errors] = "Passwords must match"
-      render :edit
+      redirect_to "/profile/#{current_user.id}/editpassword"
     end
   end
 
@@ -62,7 +62,7 @@ class UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :address, :city, :state, :zip, :email, :password)
+    params.require(:user).permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
   end
 
   def user_edit_params
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
   end
 
   def user_password_params
-    params.permit(:password)
+    params.permit(:password, :password_confirmation)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,7 +49,6 @@ class UsersController < ApplicationController
   def update_password
     @user = User.find(params[:user_id])
     @user.update(user_password_params)
-    binding.pry
     if @user.save
       flash[:success] = "#{current_user.name}, your password has been updated!"
       redirect_to "/"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true, :on => :create, :on => :update_password
+  validates_presence_of :password, require: true, :on => :create
   validates_presence_of :name,
                         :address,
                         :city,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,10 @@
 class User < ApplicationRecord
   has_secure_password
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true, :on => :create
+  validates_presence_of :password, require: true, :on => :create, :on => :update_password
+
+  validates_presence_of :password_confirmation, require: true, :on => :create, :on => :update_password
+
   validates_presence_of :name,
                         :address,
                         :city,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password, require: true, :on => :create
+  validates_presence_of :password, require: true, :on => :create, :on => :update_password
   validates_presence_of :name,
                         :address,
                         :city,

--- a/app/views/users/editpassword.html.erb
+++ b/app/views/users/editpassword.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit <%=link_to current_user.name, "/profile" %></h1>
+<center>
+  <%= form_with model: @profile, method: :patch, local: true do |f| %>
+
+    <%= f.label :password %>
+    <%= f.text_field :password %>
+
+    <%= f.label :password_confirmation %>
+    <%= f.text_field :password_confirmation, value: nil %>
+
+    <%= f.submit 'Update Password' %>
+  <% end %>
+</center>

--- a/app/views/users/editpassword.html.erb
+++ b/app/views/users/editpassword.html.erb
@@ -6,7 +6,7 @@
     <%= f.text_field :password %>
 
     <%= f.label :password_confirmation %>
-    <%= f.text_field :password_confirmation, value: nil %>
+    <%= f.text_field :password_confirmation %>
 
     <%= f.submit 'Update Password' %>
   <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -24,7 +24,7 @@
   <%= f.text_field :password, value: nil %>
 
   <%= f.label :password_confirmation %>
-  <%= f.text_field :password_confirmation %>
+  <%= f.text_field :password_confirmation, value: nil %>
 
   <%= f.submit 'Create User' %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,7 @@
     <li>Email: <%= current_user.email %></li>
     <%= link_to "Edit Profile", "/profile/#{current_user.id}/edit" %>
     <br>
-    <%= link_to "Edit Password", editpassword_user_path(current_user.id) %>
+    <%# link_to "Edit Password", editpassword_user_path(current_user.id) %>
+    <%= link_to "Edit Password", "/profile/#{current_user.id}/editpassword" %>
 
 </article>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,4 +8,7 @@
     <li>Zip: <%= current_user.zip %></li>
     <li>Email: <%= current_user.email %></li>
     <%= link_to "Edit Profile", "/profile/#{current_user.id}/edit" %>
+    <br>
+    <%= link_to "Edit Password", editpassword_user_path(current_user.id) %>
+
 </article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,8 +51,15 @@ Rails.application.routes.draw do
   get "/profile", to: "users#show"
   post '/users', to: 'users#create'
   get "/profile/:user_id/edit", to: "users#edit"
-  patch "/profile/:user_id/edit", to: "users#update" 
+  patch "/profile/:user_id/edit", to: "users#update"
 
+  resources :users do
+    member do
+      get :editpassword
+      #patch "/:user_id/editpassword"
+      patch :editpassword
+    end
+  end
   # resources :users, except: %i[new show]
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,14 +53,19 @@ Rails.application.routes.draw do
   get "/profile/:user_id/edit", to: "users#edit"
   patch "/profile/:user_id/edit", to: "users#update"
 
-  resources :users do
-    member do
-      get :editpassword
-      #patch "/:user_id/editpassword"
-      patch :editpassword
-    end
-  end
+
+  get '/profile/:user_id/editpassword', to: "users#editpassword"
+  patch "/profile/:user_id/editpassword", to: "users#update_password"
+  # resources :users do
+  #   member do
+  #     get :editpassword
+  #     patch :editpassword
+  #     #patch "/:user_id/editpassword"
+  #     #patch :update_password
+  #   end
+  # end
   # resources :users, except: %i[new show]
+
 
   namespace :admin do
     get '/', to: 'dashboard#show'

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -14,18 +14,17 @@ RSpec.describe "Logging In" do
           password: '@%)abc123#$.',
           role: 0
         )
-      end
-      it "When I click on the link to edit my profile data I see a form like the registration page" do
-
         visit '/login'
         fill_in :email, with: @user_1.email
         fill_in :password, with: @user_1.password
         click_on "Log In"
+      end
+
+      it "When I click on the link to edit my profile data I see a form like the registration page" do
 
         expect(current_path).to eq('/profile')
         expect(page).to have_link("Edit Profile")
         click_on("Edit Profile")
-
 
         expect(current_path).to eq("/profile/#{@user_1.id}/edit")
 
@@ -45,16 +44,58 @@ RSpec.describe "Logging In" do
         expect(page).to have_content('123 Main Street')
       end
 
-      it "has a link to update my password" do
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
 
-        visit '/profile'
-        expect(page).to have_link("Edit Password")
-        click_link "Edit Password"
-        expect(current_path).to eq("/users/#{@user_1.id}/editpassword")
+      it "When I leave a feild blank I receive an error" do
 
-        expect(page).to have_field(:password, with: nil)
-        #expect(page).to have_field(:password_confirmation, with: nil)
+        click_on("Edit Profile")
+
+        fill_in "Address", with: ""
+
+        click_button "Update Profile"
+        expect(current_path).to eq("/profile/#{@user_1.id}/edit")
+
+        expect(page).to have_content("Address can't be blank")
+
+      end
+
+      # it "when I click on the link to edit my password I see a field for password and confirmation" do
+
+      #   expect(current_path).to eq('/profile')
+      #   expect(page).to have_link("Edit Password")
+      #   click_on("Edit Password")
+      #
+      #   expect(current_path).to eq("/profile/#{@user_1.id}/editpassword")
+      #   save_and_open_page
+      #
+      #
+      #   expect(page).to have_field(:password)
+      #   expect(page).to have_field(:password_confirmation)
+      #   #expect(page).to_not have_field(:password, with: "#{@user_1.password}")
+      #
+      #   #expect(page).to have_field(:password_confirmation, with: "")
+      #
+      #
+      # end
+
+      it "requires a unique email address" do
+        user_2 = User.create(
+          name: 'Other Gates',
+          address: '1000 Microsoft Drive',
+          city: 'Seattle',
+          state: 'WA',
+          zip: '00123',
+          email: 'other.gates@outlook.com',
+          password: '@%)abc123#$.',
+          role: 0
+        )
+
+        click_on("Edit Profile")
+        fill_in "Email", with: "other.gates@outlook.com"
+
+        click_button "Update Profile"
+
+        expect(current_path).to eq("/profile/#{@user_1.id}/edit")
+        expect(page).to have_content("Email has already been taken")
 
       end
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe "Logging In" do
         expect(current_path).to eq('/profile')
         expect(page).to have_link("Edit Profile")
         click_on("Edit Profile")
-
         expect(current_path).to eq("/profile/#{@user_1.id}/edit")
-
         expect(page).to have_field(:name, with: "#{@user_1.name}")
         expect(page).to have_field(:address, with: "#{@user_1.address}")
         expect(page).to have_field(:city, with: "#{@user_1.city}")
@@ -36,46 +34,45 @@ RSpec.describe "Logging In" do
         expect(page).to have_field(:email, with: "#{@user_1.email}")
         expect(page).to_not have_field(:password, with: "#{@user_1.password}")
         expect(page).to_not have_field(:password_confirmation, with: "#{@user_1.password_confirmation}")
-
         fill_in "Address", with: '123 Main Street'
-
         click_button "Update Profile"
         expect(current_path).to eq("/profile")
         expect(page).to have_content('123 Main Street')
       end
 
-
       it "When I leave a feild blank I receive an error" do
 
         click_on("Edit Profile")
-
         fill_in "Address", with: ""
-
         click_button "Update Profile"
         expect(current_path).to eq("/profile/#{@user_1.id}/edit")
-
         expect(page).to have_content("Address can't be blank")
-
       end
 
-      # it "when I click on the link to edit my password I see a field for password and confirmation" do
+      it "when I click on the link to edit my password I see a field for password and confirmation" do
 
-      #   expect(current_path).to eq('/profile')
-      #   expect(page).to have_link("Edit Password")
-      #   click_on("Edit Password")
-      #
-      #   expect(current_path).to eq("/profile/#{@user_1.id}/editpassword")
-      #   save_and_open_page
-      #
-      #
-      #   expect(page).to have_field(:password)
-      #   expect(page).to have_field(:password_confirmation)
-      #   #expect(page).to_not have_field(:password, with: "#{@user_1.password}")
-      #
-      #   #expect(page).to have_field(:password_confirmation, with: "")
-      #
-      #
-      # end
+        expect(current_path).to eq('/profile')
+        expect(page).to have_link("Edit Password")
+        click_on("Edit Password")
+        expect(current_path).to eq("/profile/#{@user_1.id}/editpassword")
+        expect(page).to have_field(:password)
+        expect(page).to have_field(:password_confirmation)
+        fill_in "Password", with: '123'
+        fill_in "Password confirmation", with: '123'
+        click_on("Update Password")
+        expect(current_path).to eq("/profile")
+        expect(page).to have_content("#{@user_1.name}, your password has been updated!")
+      end
+
+      it "if password doesn't match password confirmation there is an error" do
+
+        click_on("Edit Password")
+        fill_in "Password", with: '123'
+        fill_in "Password confirmation", with: '321'
+        click_on("Update Password")
+        expect(current_path).to eq("/profile/#{@user_1.id}/editpassword")
+        expect(page).to have_content("Passwords must match")
+      end
 
       it "requires a unique email address" do
         user_2 = User.create(
@@ -91,14 +88,10 @@ RSpec.describe "Logging In" do
 
         click_on("Edit Profile")
         fill_in "Email", with: "other.gates@outlook.com"
-
         click_button "Update Profile"
-
         expect(current_path).to eq("/profile/#{@user_1.id}/edit")
         expect(page).to have_content("Email has already been taken")
-
       end
-
     end
   end
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe "Logging In" do
         expect(page).to have_content('123 Main Street')
       end
 
+      it "has a link to update my password" do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+        visit '/profile'
+        expect(page).to have_link("Edit Password")
+        click_link "Edit Password"
+        expect(current_path).to eq("/users/#{@user_1.id}/editpassword")
+
+        expect(page).to have_field(:password, with: nil)
+        #expect(page).to have_field(:password_confirmation, with: nil)
+
+      end
+
     end
   end
 


### PR DESCRIPTION
This is quite a PR and it includes 21 and 22. I would like to speak via zoom or slack with whoever wants to review for a couple of reasons.

I had to alter models/user to include validate password_confirmation. We were never testing or ensuring that password and password_confirmation were working together.

I would also like to gameplan about the routes that I made. In order to make US 21 & 22 work I resorted to non-restful routes. The good news is the functionality is there, that the stories didn't dictate specific routes, and that every test passes. The downside is I know that the routes can be and should be cleaned up.

We may also need to write some tests regarding registration and using a confirmation password that does not match the password field.
