### PR TITLE
I2 30 ordershow

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -26,8 +26,25 @@ class OrdersController < ApplicationController
          render :new
        end
      end
-   end
+  end
 
+  def destroy
+    order = Order.find(params[:id])
+    if order.save
+      order.item_orders.each do |item_order|
+        item = Item.find(item_order.item_id)
+        item.inventory += item_order.quantity
+        item.save
+        item_order.update(status: "unfulfilled")
+        item_order.save
+      end
+      order.update(status: "cancelled")
+      flash[:success] = "Your order has been cancelled!"
+    else
+      flash[:error] = "Unable to cancel this order!"
+    end
+    redirect_to "/profile/orders"
+  end
 
   private
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -30,14 +30,8 @@ class OrdersController < ApplicationController
 
   def destroy
     order = Order.find(params[:id])
-    if order.save
-      order.item_orders.each do |item_order|
-        item = Item.find(item_order.item_id)
-        item.inventory += item_order.quantity
-        item.save
-        item_order.update(status: "unfulfilled")
-        item_order.save
-      end
+    if order
+      order.item_attributes_update(order)
       order.update(status: "cancelled")
       flash[:success] = "Your order has been cancelled!"
     else

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,7 +4,16 @@ class Order <ApplicationRecord
   has_many :item_orders
   has_many :items, through: :item_orders
   belongs_to :user, optional: true
+
   def grandtotal
     item_orders.sum('price * quantity')
+  end
+
+  def item_attributes_update(order)
+    order.item_orders.each do |item_order|
+      item = Item.find(item_order.item_id)
+      item.inventory += item_order.quantity if item_order.status == "fulfilled"
+      item_order.update(status: "unfulfilled")
+    end
   end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -39,18 +39,18 @@
 
   <% @order.item_orders.each do |item_order|%>
     <tr>
-    <section id = "item-<%=item_order.item_id%>">
+      <section id = "item-<%=item_order.item_id%>">
         <td><img src="<%= item_order.item.image %>" width="100" height="100"</img></td>
-        <td><p><%= @order.id %></p></td>
-        <td><p><%= item_order.status %></p></td>
-        <td><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></td>
-        <td><p><%= @order.items.first.description %></p></td>
-        <td><p><%= link_to item_order.item.merchant.name, "/merchants/#{item_order.item.merchant.id}"%></p></td>
-        <td><p><%= number_to_currency(item_order.price)%></p></td>
-        <td><p><%= item_order.quantity%></p></td>
-        <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
-        <td><p><%= @order.created_at.localtime.strftime("%m/%d/%y") %></p></td>
-        <td><p><%= @order.updated_at.localtime.strftime("%m/%d/%y") %></p></td>
+        <td><%= @order.id %></td>
+        <td><section class='item-<%= item_order.item_id %>-order-status-cell'><%= item_order.status %></section></td>
+        <td><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></td>
+        <td><%= @order.items.first.description %></td>
+        <td><%= link_to item_order.item.merchant.name, "/merchants/#{item_order.item.merchant.id}"%></td>
+        <td><%= number_to_currency(item_order.price)%></td>
+        <td><%= item_order.quantity%></td>
+        <td><%= number_to_currency(item_order.subtotal)%></td>
+        <td><%= @order.created_at.localtime.strftime("%m/%d/%y") %></td>
+        <td><%= @order.updated_at.localtime.strftime("%m/%d/%y") %></td>
       </section>
     </tr>
   <% end %>
@@ -63,6 +63,7 @@
 </section>
 <section id="datecreated">
   <p>Order Placed: <%= @order.created_at.localtime.strftime("%B %d, %Y at %l:%M %p") %></p>
-  if @order.status
-  <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :delete %>
+  <% if @order.status != 'cancelled' %>
+    <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :delete %>
+  <% end %>
 </section>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -18,46 +18,51 @@
   </table>
 </section>
 
-<h1 align = "center">Order Info</h1>
-<center>
-  <table>
-    <tr>
-      <th>Image</th>
-      <th>Order ID</th>
-      <th>Status</th>
-      <th>Item</th>
-      <th>Description</th>
-      <th>Sold By</th>
-      <th>Price</th>
-      <th>Quantity</th>
-      <th>Subtotal</th>
-      <th>Date Created</th>
-      <th>Date Updated</th>
+<section class="order-info">
+  <h1 align = "center">Order Info</h1>
+  <center>
+    <table>
+      <tr>
+        <th>Image</th>
+        <th>Order ID</th>
+        <th>Item Status</th>
+        <th>Item</th>
+        <th>Description</th>
+        <th>Sold By</th>
+        <th>Price</th>
+        <th>Quantity</th>
+        <th>Subtotal</th>
+        <th>Date Created</th>
+        <th>Date Updated</th>
+      </tr>
+</section>
 
-    </tr>
   <% @order.item_orders.each do |item_order|%>
     <tr>
     <section id = "item-<%=item_order.item_id%>">
         <td><img src="<%= item_order.item.image %>" width="100" height="100"</img></td>
         <td><p><%= @order.id %></p></td>
-        <td><p><%= @order.status %></p></td>
+        <td><p><%= item_order.status %></p></td>
         <td><p><%=link_to item_order.item.name, "/items/#{item_order.item_id}"%></p></td>
         <td><p><%= @order.items.first.description %></p></td>
         <td><p><%= link_to item_order.item.merchant.name, "/merchants/#{item_order.item.merchant.id}"%></p></td>
         <td><p><%= number_to_currency(item_order.price)%></p></td>
         <td><p><%= item_order.quantity%></p></td>
         <td><p><%= number_to_currency(item_order.subtotal)%></p></td>
-        <td><p><%= @order.created_at.strftime("%m/%d/%y") %></p></td>
-        <td><p><%= @order.updated_at.strftime("%m/%d/%y") %></p></td>
+        <td><p><%= @order.created_at.localtime.strftime("%m/%d/%y") %></p></td>
+        <td><p><%= @order.updated_at.localtime.strftime("%m/%d/%y") %></p></td>
       </section>
     </tr>
   <% end %>
 </table>
 
 <section id="grandtotal">
+  <p>Order Status: <%= @order.status %></p>
   <p>Number of Items in Order: <%= @order.items.count%></p>
   <p>Total: <%=number_to_currency(@order.grandtotal)%></p>
 </section>
 <section id="datecreated">
-  <p> <%= @order.created_at%></p>
+  <p>Order Placed: <%= @order.created_at.localtime.strftime("%B %d, %Y at %l:%M %p") %></p>
+  if @order.status
+  <p><%= button_to "Cancel Order", "/profile/orders/#{@order.id}", method: :delete %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,9 +47,10 @@ Rails.application.routes.draw do
 
   get "/orders/new", to: "orders#new"
   post "/orders", to: "orders#create"
-  
+
   get "/profile/orders", to: "orders#index"
   get "/profile/orders/:id", to: "orders#show"
+  delete "profile/orders/:id", to: "orders#destroy"
 
 
   get "/register", to: "users#new"

--- a/db/migrate/20200915212453_add_status_to_item_orders.rb
+++ b/db/migrate/20200915212453_add_status_to_item_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToItemOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :item_orders, :status, :string, default: 'processing'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_15_002322) do
+ActiveRecord::Schema.define(version: 2020_09_15_212453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_09_15_002322) do
     t.integer "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "processing"
     t.index ["item_id"], name: "index_item_orders_on_item_id"
     t.index ["order_id"], name: "index_item_orders_on_order_id"
   end

--- a/spec/features/orders/show_spec.rb
+++ b/spec/features/orders/show_spec.rb
@@ -57,29 +57,38 @@ RSpec.describe 'Profile Orders' do
 
     it "When I click the cancel button, each row is given a status of unfulfilled" do
       visit("/profile/orders/#{@user_1.orders.first.id}")
-      within ".order-info" do
-        expect(page).to have_content("pending")
+      within ".item-#{@user_1.orders.first.item_orders.first.item_id}-order-status-cell" do
+        expect(page).to have_content("processing")
+      end
+      within ".item-#{@user_1.orders.first.item_orders.last.item_id}-order-status-cell" do
+        expect(page).to have_content("processing")
       end
 
       click_button("Cancel Order")
 
       visit("/profile/orders/#{@user_1.orders.first.id}")
-      within ".order-info" do
-        expect(page).to have_content("cancelled")
+      within ".item-#{@user_1.orders.first.item_orders.first.item_id}-order-status-cell" do
+        expect(page).to have_content("unfulfilled")
       end
-
+      within ".item-#{@user_1.orders.first.item_orders.last.item_id}-order-status-cell" do
+        expect(page).to have_content("unfulfilled")
+      end
     end
+
     it "The order itself is given a status of cancelled" do
       visit("/profile/orders/#{@user_1.orders.first.id}")
       click_button("Cancel Order")
-
+      expect(page).to have_content("Your order has been cancelled!")
 
     end
 
     it "Any item quantities in the order have their quantities returned to their respective values" do
       visit("/profile/orders/#{@user_1.orders.first.id}")
+      expect(@user_1.orders.first.item_orders.first.item.inventory).to eq(@mike.items.find(@user_1.orders.first.item_orders.first.item.id).inventory)
+
       click_button("Cancel Order")
 
+      expect(@user_1.orders.first.item_orders.first.item.inventory).to eq(@mike.items.find(@user_1.orders.first.item_orders.first.item.id).inventory)
     end
 
     it "I am returned to my profile page, I see a flash message telling me the order is now cancelled, and see the order status change" do
@@ -87,7 +96,13 @@ RSpec.describe 'Profile Orders' do
       click_button("Cancel Order")
       expect(current_path).to eq("/profile/orders")
       expect(page).to have_content("Your order has been cancelled!")
+    end
 
+    it "I don't see a cancel button if an order has already been cancelled" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      click_button("Cancel Order")
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      expect(page).to_not have_link("Cancel Order")
     end
   end
 end

--- a/spec/features/orders/show_spec.rb
+++ b/spec/features/orders/show_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe 'Profile Orders' do
       click_on "Confirmation number: #{@user_1.orders.first.id}"
       expect(page).to have_css("img[src*='#{"https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png"}']")
       expect(page).to have_content("#{@user_1.orders.first.id}")
-      expect(page).to have_content(@user_1.orders.first.created_at.strftime("%m/%d/%y"))
-      expect(page).to have_content(@user_1.orders.first.updated_at.strftime("%m/%d/%y"))
+      expect(page).to have_content(@user_1.orders.first.created_at.localtime.strftime("%m/%d/%y"))
+      expect(page).to have_content(@user_1.orders.first.updated_at.localtime.strftime("%m/%d/%y"))
       expect(page).to have_content("pending")
       expect(page).to have_content(@user_1.orders.first.items.first.name)
       expect(page).to have_content(@user_1.orders.first.items.first.description)
@@ -47,6 +47,47 @@ RSpec.describe 'Profile Orders' do
       expect(page).to have_content(@user_1.orders.first.item_orders.first.subtotal)
       expect(page).to have_content("Number of Items in Order: #{@user_1.orders.first.items.count}")
       expect(page).to have_content("Total: $122.00")
+    end
+
+    it "I see a button to cancel the order" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      expect(page).to have_button("Cancel Order")
+
+    end
+
+    it "When I click the cancel button, each row is given a status of unfulfilled" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      within ".order-info" do
+        expect(page).to have_content("pending")
+      end
+
+      click_button("Cancel Order")
+
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      within ".order-info" do
+        expect(page).to have_content("cancelled")
+      end
+
+    end
+    it "The order itself is given a status of cancelled" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      click_button("Cancel Order")
+
+
+    end
+
+    it "Any item quantities in the order have their quantities returned to their respective values" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      click_button("Cancel Order")
+
+    end
+
+    it "I am returned to my profile page, I see a flash message telling me the order is now cancelled, and see the order status change" do
+      visit("/profile/orders/#{@user_1.orders.first.id}")
+      click_button("Cancel Order")
+      expect(current_path).to eq("/profile/orders")
+      expect(page).to have_content("Your order has been cancelled!")
+
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -33,5 +33,13 @@ describe Order, type: :model do
     it 'grandtotal' do
       expect(@order_1.grandtotal).to eq(230)
     end
+
+    it 'item_attributes_update' do
+      @order_1.item_attributes_update(@order_1)
+      expect(@order_1.item_orders.first.status).to eq("unfulfilled")
+      expect(@order_1.item_orders.last.status).to eq("unfulfilled")
+      expect(@order_1.items.first.inventory).to eq(12)
+      expect(@order_1.items.last.inventory).to eq(32)
+    end
   end
 end


### PR DESCRIPTION
Adds
- Cancel order test
- Destroy action in orders controller
- Cancel button in cart show
- Updates order time to local time zone 
- Updates order profile page to include item order status
- Adds status and default of processing to item orders table

This may have to be updated down the line to work with some of the other stories, where we decrement the inventory once and order is fulfilled. I also noticed that the cancel order is still visible on orders that have been cancelled already, I would like to pair up possibly and work through adding in some if logic, outside of the story maybe, to make this work better.